### PR TITLE
fix: [FEATURE]: Ordering of `vars` and `selectors`

### DIFF
--- a/src/css-rules/concentric-order/concentric-groups.ts
+++ b/src/css-rules/concentric-order/concentric-groups.ts
@@ -328,6 +328,8 @@ export const concentricGroups: { [key: string]: string[] } = {
   counters: ['counter-reset', 'counter-increment', 'counter-set'],
 
   breaks: ['page-break-before', 'page-break-after', 'page-break-inside', 'break-before', 'break-after', 'break-inside'],
+  vars: ['vars'],
+  selectors: ['selectors'],
 };
 
 /**


### PR DESCRIPTION
Closes #5